### PR TITLE
Dynamically-linked MSVC runtime library

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -84,7 +84,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 # Visual Studio
 set(CMAKE_MSVC_RUNTIME_LIBRARY
-  "$<IF:$<OR:$<BOOL:${ENABLE_SANITIZERS}>,$<BOOL:${BUILD_UNIT_TESTS}>>,MultiThreadedDLL,MultiThreaded$<$<CONFIG:Debug>:Debug>>"
+  "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
 )
 set(CMAKE_VS_GLOBALS
   "RunCodeAnalysis=false"


### PR DESCRIPTION
Dynamically-linked MSVC runtime library instead of the statically-linked to eliminate antivirus false positives and reduce the binary size.
<details>
  <summary><b>BEFORE</b></summary>
  <p align="center">
    <img src="https://user-images.githubusercontent.com/43341889/204464004-7b46e236-ad3c-44ab-a17c-942123cd191e.png" alt="BEFORE">
  </p>
</details>
<details>
  <summary><b>AFTER</b></summary>
  <p align="center">
    <img src="https://user-images.githubusercontent.com/43341889/204464514-abeb67f0-be14-44b6-a244-6e343c44c1f4.png" alt="AFTER">
  </p>
</details>
