### PR TITLE
Add support for the -conclearlog command-line option

### DIFF
--- a/dedicated/src/command_line.cpp
+++ b/dedicated/src/command_line.cpp
@@ -123,31 +123,33 @@ namespace rehlds::dedicated
         return count;
     }
 
-    bool CommandLine::find_param(std::string param) const
+    bool CommandLine::find_param(std::string regex_pattern) const
     {
-        boost::algorithm::trim(param);
+        boost::algorithm::trim(regex_pattern);
+        const std::regex regex{regex_pattern, std::regex_constants::icase};
         auto found = false;
 
         enumerate_params(current(),
-          [&param, &found](const std::smatch& match)
+          [&regex, &found](const std::smatch& match)
           {
               const auto& [param_name, param_values] = split_param(match.str());
-              return (found = boost::algorithm::iequals(param_name, param));
+              return (found = std::regex_match(param_name, regex));
           });
 
         return found;
     }
 
-    bool CommandLine::find_param(std::string param, std::string& values) const
+    bool CommandLine::find_param(std::string regex_pattern, std::string& values) const
     {
-        boost::algorithm::trim(param);
+        boost::algorithm::trim(regex_pattern);
+        const std::regex regex{regex_pattern, std::regex_constants::icase};
         auto found = false;
 
         enumerate_params(current(),
-          [&param, &values, &found](const std::smatch& match)
+          [&regex, &values, &found](const std::smatch& match)
           {
               const auto& [param_name, param_values] = split_param(match.str());
-              found = boost::algorithm::iequals(param_name, param);
+              found = std::regex_match(param_name, regex);
 
               if (found) {
                   values = param_values;

--- a/dedicated/src/command_line.h
+++ b/dedicated/src/command_line.h
@@ -51,12 +51,12 @@ namespace rehlds::dedicated
         /**
          * @brief Search for the parameter in the current commandline.
          */
-        [[nodiscard]] bool find_param(std::string param) const;
+        [[nodiscard]] bool find_param(std::string regex_pattern) const;
 
         /**
          * @brief Search for the parameter in the current commandline.
          */
-        bool find_param(std::string param, std::string& values) const;
+        bool find_param(std::string regex_pattern, std::string& values) const;
 
         /**
          * @brief Remove specified string (and any args attached to it) from command line.

--- a/dedicated/src/dedicated.cpp
+++ b/dedicated/src/dedicated.cpp
@@ -65,24 +65,7 @@ namespace
 #ifdef _WIN32
         cmdline.set_param("-console");
 #endif
-
         cmdline.set_param("-steam");
-    }
-
-    void init_pidfile(const CommandLine& cmdline)
-    {
-        if (std::string pidfile{}; cmdline.find_param("-pidfile", pidfile) && (!pidfile.empty())) {
-            std::ofstream filestream{};
-            filestream.open(pidfile, std::ios_base::out | std::ios_base::trunc);
-
-            if (filestream.good() && filestream.is_open()) {
-                filestream << get_pid() << '\n';
-                filestream.close();
-            }
-            else {
-                TextConsole::print("Warning: unable to open PID file (%s)\n", pidfile);
-            }
-        }
     }
 
     void init_pingboost(const CommandLine& cmdline, HldsModule& engine_module)
@@ -139,6 +122,22 @@ namespace
         return true;
     }
 
+    void process_param_pidfile(const CommandLine& cmdline)
+    {
+        if (std::string pidfile{}; cmdline.find_param("-pidfile", pidfile) && (!pidfile.empty())) {
+            std::ofstream filestream{};
+            filestream.open(pidfile, std::ios_base::out | std::ios_base::trunc);
+
+            if (filestream.good() && filestream.is_open()) {
+                filestream << get_pid() << '\n';
+                filestream.close();
+            }
+            else {
+                TextConsole::print("Warning: unable to open PID file (%s)\n", pidfile);
+            }
+        }
+    }
+
     /**
      * @brief Server loop.
      */
@@ -184,7 +183,7 @@ namespace rehlds::dedicated
 
         filesystem->mount();
         init_cmdline(cmdline);
-        init_pidfile(cmdline);
+        process_param_pidfile(cmdline);
         init_pingboost(cmdline, engine_module);
 
         auto* const launcher_factory = get_factory_this();

--- a/dedicated/src/dedicated.cpp
+++ b/dedicated/src/dedicated.cpp
@@ -12,6 +12,7 @@
 #include "sleep.h"
 #include <cassert>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 
 #ifdef _WIN32
@@ -105,6 +106,21 @@ namespace
         }
     }
 
+    void process_param_conclearlog(const CommandLine& cmdline)
+    {
+        if (cmdline.find_param("[-\\+]condebug") && cmdline.find_param("-conclearlog")) {
+#ifdef _WIN32
+            std::error_code error_code{};
+            std::filesystem::remove("qconsole.log", error_code);
+#else
+            if (std::string game{}; cmdline.find_param("-game", game) && (!game.empty())) {
+                std::error_code error_code{};
+                std::filesystem::remove(game + "/qconsole.log", error_code);
+            }
+#endif
+        }
+    }
+
     void process_param_pingboost(const CommandLine& cmdline, HldsModule& engine_module)
     {
         sys_sleep = &sleep_thread_millisecond;
@@ -184,6 +200,7 @@ namespace rehlds::dedicated
         filesystem->mount();
         init_cmdline(cmdline);
         process_param_pidfile(cmdline);
+        process_param_conclearlog(cmdline);
         process_param_pingboost(cmdline, engine_module);
 
         auto* const launcher_factory = get_factory_this();

--- a/dedicated/test/test_command_line.cpp
+++ b/dedicated/test/test_command_line.cpp
@@ -89,15 +89,15 @@ namespace rehlds::dedicated::test
         cmdline.create(args1.size(), args1.data());
         ASSERT_TRUE(cmdline.current().empty());
 
-        constexpr std::array<const char*, 2> args2 = {"hlds.exe", "param value"};
+        constexpr std::array args2 = {"hlds.exe", "param value"};
         cmdline.create(args2.size(), args2.data());
         ASSERT_TRUE(cmdline.current().empty());
 
-        constexpr std::array<const char*, 3> args3 = {"hlds.exe", " -game  ", "\tcstrike\r\n"};
+        constexpr std::array args3 = {"hlds.exe", " -game  ", "\tcstrike\r\n"};
         cmdline.create(args3.size(), args3.data());
         ASSERT_TRUE("-game cstrike" == cmdline.current());
 
-        constexpr std::array<const char*, 4> args4 = {"hlds.exe", " -game  ", "\tcstrike\r\n", "\f@hlds_params1\n"};
+        constexpr std::array args4 = {"hlds.exe", " -game  ", "\tcstrike\r\n", "\f@hlds_params1\n"};
         cmdline.create(args4.size(), args4.data());
         ASSERT_TRUE("-game cstrike +maxplayers 31 -num_edicts 2048 +map de_dust" == cmdline.current());
     }
@@ -113,15 +113,21 @@ namespace rehlds::dedicated::test
         found_param = cmdline.find_param("\t\t -gAmE \r\n");
         ASSERT_TRUE(found_param);
 
+        found_param = cmdline.find_param("-gam");
+        ASSERT_FALSE(found_param);
+
+        found_param = cmdline.find_param("-games");
+        ASSERT_FALSE(found_param);
+
         found_param = cmdline.find_param("\t\t -gAmE \r\n", values);
         ASSERT_TRUE(found_param);
         ASSERT_STRCASEEQ(values.c_str(), "cstrike");
 
-        found_param = cmdline.find_param("+sys_ticrate \r\n", values);
+        found_param = cmdline.find_param("\\+sys_ticrate \r\n", values);
         ASSERT_TRUE(found_param);
         ASSERT_TRUE("1000" == values);
 
-        found_param = cmdline.find_param("\t\t +maxplayers", values);
+        found_param = cmdline.find_param("\t\t \\+maxplayers", values);
         ASSERT_TRUE(found_param);
         ASSERT_TRUE("32" == values);
     }


### PR DESCRIPTION
Command-line option `-conclearlog` clears the `qconsole.log` text file on start. Only works if `-condebug` set.
This [option](https://developer.valvesoftware.com/wiki/Command_Line_Options) is also available for games on the Source engine.