### PR TITLE
Add -ignoresigint command-line option support

### DIFF
--- a/dedicated/src/console/text_console_windows.cpp
+++ b/dedicated/src/console/text_console_windows.cpp
@@ -29,11 +29,6 @@ namespace
 
         return attributes;
     }
-
-    ::BOOL WINAPI console_handler_routine(const ::DWORD /* unused */)
-    {
-        return TRUE;
-    }
 }
 
 namespace rehlds::dedicated
@@ -69,10 +64,6 @@ namespace rehlds::dedicated
         handle_input = ::GetStdHandle(STD_INPUT_HANDLE);
         handle_output = ::GetStdHandle(STD_OUTPUT_HANDLE);
         set_title("GoldSrc Dedicated Server");
-
-        if (FALSE == ::SetConsoleCtrlHandler(&console_handler_routine, TRUE)) {
-            print("WARNING! TextConsoleWindows::init: Could not attach console hook.\n");
-        }
 
         return true;
     }

--- a/dedicated/src/dedicated.cpp
+++ b/dedicated/src/dedicated.cpp
@@ -11,6 +11,7 @@
 #include "console/text_console.h"
 #include "sleep.h"
 #include <cassert>
+#include <csignal>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -121,6 +122,13 @@ namespace
         }
     }
 
+    void process_param_ignoresigint(const CommandLine& cmdline)
+    {
+        if (cmdline.find_param("-ignoresigint") && (SIG_ERR == std::signal(SIGINT, SIG_IGN))) {
+            TextConsole::print("WARNING! -ignoresigint: Failed to set signal handler.\n");
+        }
+    }
+
     void process_param_pingboost(const CommandLine& cmdline, HldsModule& engine_module)
     {
         sys_sleep = &sleep_thread_millisecond;
@@ -201,6 +209,7 @@ namespace rehlds::dedicated
         init_cmdline(cmdline);
         process_param_pidfile(cmdline);
         process_param_conclearlog(cmdline);
+        process_param_ignoresigint(cmdline);
         process_param_pingboost(cmdline, engine_module);
 
         auto* const launcher_factory = get_factory_this();


### PR DESCRIPTION
Ignore signal INT (prevents CTRL+C quitting) (Windows/Linux).
This [option](https://developer.valvesoftware.com/wiki/Command_Line_Options) is also available for games on the Source engine.