### PR TITLE
Fix console output encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -508,4 +508,5 @@ out/
 # Miscellaneous
 .idea/
 *.snalyzerinfo
+dedicated/*.manifest
 resource.rc

--- a/.pvs-studio
+++ b/.pvs-studio
@@ -1,3 +1,3 @@
 exclude-path = */Microsoft Visual Studio/*
 exclude-path = */boost/*
-exclude-path = */libs/*
+exclude-path = **fmtlib**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 string(SUBSTRING "${GIT_SHA1}" 0 7 GIT_SHA1_TRUNC)
 
 FetchContent_Declare(
+  FmtLib
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG        9.1.0
+)
+
+FetchContent_Declare(
   PVS_CMakeModule
   GIT_REPOSITORY https://github.com/viva64/pvs-studio-cmake-module.git
   GIT_TAG        master
@@ -87,6 +93,14 @@ else()
   # MSVC.cmake GNU.cmake, Clang.cmake, Intel.cmake
   include(${CMAKE_CXX_COMPILER_ID})
 endif()
+
+set(FMT_SYSTEM_HEADERS ON)
+FetchContent_MakeAvailable(FmtLib)
+
+target_compile_options(fmt PRIVATE $<IF:$<PLATFORM_ID:Windows>,/w,-w>)
+setup_target_compile_definitions(fmt)
+setup_target_compile_options(fmt)
+setup_target_link_options(fmt)
 
 add_subdirectory("common")
 add_subdirectory("dedicated")

--- a/cmake/ClangCL.cmake
+++ b/cmake/ClangCL.cmake
@@ -130,7 +130,7 @@ function(setup_target_link_options)
     target_link_options("${target_name}" PRIVATE
       /GUARD:NO             # Control flow guard protection
       /MACHINE:X86          # The target platform
-      /MANIFEST:NO          # Create assembly manifest
+      #/MANIFEST:NO         # Create assembly manifest
       /NXCOMPAT             # Compatible with the Windows Data Execution Prevention feature
       /SUBSYSTEM:CONSOLE    # Subsystem
       /WX                   # Treat linker warnings as errors

--- a/cmake/ClangCL.cmake
+++ b/cmake/ClangCL.cmake
@@ -5,8 +5,10 @@
 # setup_target_compile_options(target1 target2 ...)
 function(setup_target_compile_options)
   foreach(target_name ${ARGV})
-    target_compile_options("${target_name}" PRIVATE
-      /W4                     # Output warning level (/W4 enables -Wall and -Wextra)
+    get_target_property(tgt_compile_options "${target_name}" COMPILE_OPTIONS)
+    list(FILTER tgt_compile_options INCLUDE REGEX "/[wW]([,0-9]|$)")
+
+    target_compile_options("${target_name}" PRIVATE      
       -Wpedantic
       -Wcast-align
       -Wcast-qual
@@ -23,6 +25,10 @@ function(setup_target_compile_options)
       /permissive-            # Standard-conformance mode
       /source-charset:utf-8   # Character set of source files
       /Zc:threadSafeInit-     # Thread-safe local static initialization
+
+      $<$<NOT:$<BOOL:${tgt_compile_options}>>:
+        /W4                   # Output warning level (/W4 enables -Wall and -Wextra)
+      >
 
       # AddressSanitizer
       $<$<BOOL:${SANITIZE_ADDRESS}>:

--- a/cmake/MSVC.cmake
+++ b/cmake/MSVC.cmake
@@ -141,7 +141,7 @@ function(setup_target_link_options)
       /CGTHREADS:${NCORES}  # Number of cl.exe threads to use for optimization and code generation
       /GUARD:NO             # Control flow guard protection
       /MACHINE:X86          # The target platform
-      /MANIFEST:NO          # Create assembly manifest
+      #/MANIFEST:NO         # Create assembly manifest
       /NXCOMPAT             # Compatible with the Windows Data Execution Prevention feature
       /SUBSYSTEM:CONSOLE    # Subsystem
       /WX                   # Treat linker warnings as errors

--- a/cmake/MSVC.cmake
+++ b/cmake/MSVC.cmake
@@ -5,10 +5,11 @@
 # setup_target_compile_options(target1 target2 ...)
 function(setup_target_compile_options)
   foreach(target_name ${ARGV})
-    target_compile_options("${target_name}" PRIVATE
-      /W4                     # Output warning level
-      /wd4706                 # Disable warning (assignment within conditional expression)
+    get_target_property(tgt_compile_options "${target_name}" COMPILE_OPTIONS)
+    list(FILTER tgt_compile_options INCLUDE REGEX "/[wW]([,0-9]|$)")
 
+    target_compile_options("${target_name}" PRIVATE
+      /wd4706                 # Disable warning (assignment within conditional expression)
       /arch:SSE2              # Minimum CPU architecture requirements
       /cgthreads${NCORES}     # Number of cl.exe threads to use for optimization and code generation
       /diagnostics:caret      # Diagnostics format: prints column and the indicated line of source
@@ -22,6 +23,10 @@ function(setup_target_compile_options)
       /source-charset:utf-8   # Character set of source files
       /validate-charset       # Validate UTF-8 files for only compatible characters
       /Zc:threadSafeInit-     # Thread-safe local static initialization
+
+      $<$<NOT:$<BOOL:${tgt_compile_options}>>:
+        /W4                   # Output warning level
+      >
 
       $<$<OR:$<BOOL:${MICROSOFT_CODE_ANALYSIS}>,$<BOOL:${CLANG_TIDY_CODE_ANALYSIS}>>:
         /analyze              # Enable code analysis

--- a/dedicated/CMakeLists.txt
+++ b/dedicated/CMakeLists.txt
@@ -44,6 +44,7 @@ target_include_directories(${PROJECT_NAME_INTERFACE} INTERFACE
 )
 
 target_link_libraries(${PROJECT_NAME_INTERFACE} INTERFACE
+  fmt::fmt
   Boost::boost
   ReHLDS::common
 

--- a/dedicated/CMakeLists.txt
+++ b/dedicated/CMakeLists.txt
@@ -76,9 +76,22 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 if(WIN32)
+  target_compile_definitions("${PROJECT_NAME}" PRIVATE
+    _CONSOLE
+  )
+
+  target_link_options(${PROJECT_NAME} PRIVATE
+    "/MANIFESTUAC:level='asInvoker' uiAccess='false'"
+    /MANIFEST
+  )
+
+  configure_file("hlds.exe.manifest.in" "${PROJECT_SOURCE_DIR}/hlds.exe.manifest" @ONLY)
   configure_file("resource.rc.in" "${PROJECT_SOURCE_DIR}/resource.rc" @ONLY)
-  target_sources(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/resource.rc")
-  target_compile_definitions("${PROJECT_NAME}" PRIVATE _CONSOLE)
+
+  target_sources(${PROJECT_NAME} PRIVATE
+    "${PROJECT_SOURCE_DIR}/hlds.exe.manifest"
+    "${PROJECT_SOURCE_DIR}/resource.rc"
+  )
 elseif(UNIX AND NOT APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES
     SUFFIX "_linux"

--- a/dedicated/hlds.exe.manifest.in
+++ b/dedicated/hlds.exe.manifest.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="@CMAKE_PROJECT_NAME@" version="@CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@.@CMAKE_PROJECT_VERSION_PATCH@.@CMAKE_PROJECT_VERSION_TWEAK@"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+  <trustInfo>
+    <security>
+      <requestedPrivileges>
+         <requestedExecutionLevel level='asInvoker' uiAccess='false'/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/dedicated/src/command_line.cpp
+++ b/dedicated/src/command_line.cpp
@@ -223,7 +223,7 @@ namespace rehlds::dedicated
         std::ifstream file_stream{filename};
 
         if (!file_stream.good()) {
-            TextConsole::print("\n\nParameter file '%s' not found, skipping...", filename.c_str());
+            TextConsole::print("\n\nParameter file '{}' not found, skipping...", filename.c_str());
             return;
         }
 

--- a/dedicated/src/console/text_console.cpp
+++ b/dedicated/src/console/text_console.cpp
@@ -12,7 +12,6 @@
 #include <cassert>
 #include <cctype>
 #include <chrono>
-#include <clocale>
 #include <cstring>
 #include <iostream>
 #include <utility>
@@ -21,7 +20,7 @@ using namespace rehlds::common;
 
 namespace
 {
-    rehlds::common::IDedicatedServerApi* engine_api{};
+    IDedicatedServerApi* engine_api{};
 
     std::pair<std::string_view, std::string_view> get_smallest_longest_commands(const ObjectList& commands)
     {
@@ -59,18 +58,8 @@ namespace rehlds::dedicated
         browse_line_ = 0;
         detail::system = get_engine_module().get_system();
 
-#ifdef _WIN32
-        constexpr auto* locale = ".UTF-8";
-#else
-        constexpr auto* locale = "C.UTF-8";
-#endif
-        // NOLINTNEXTLINE(concurrency-mt-unsafe)
-        if (nullptr == std::setlocale(LC_ALL, locale)) {
-            print("WARNING! TextConsole::init: Could not set locale.\n");
-        }
-
-        auto& engine_module = common::get_engine_module();
-        engine_api = engine_module.get_interface<common::IDedicatedServerApi>(common::INTERFACE_DEDICATED_SERVER_API);
+        auto& engine_module = get_engine_module();
+        engine_api = engine_module.get_interface<IDedicatedServerApi>(INTERFACE_DEDICATED_SERVER_API);
         initialized_ = engine_api != nullptr;
 
         return initialized_;

--- a/dedicated/src/console/text_console_unix.cpp
+++ b/dedicated/src/console/text_console_unix.cpp
@@ -79,7 +79,7 @@ namespace
             buffer_stored = std::cout.rdbuf(tty.rdbuf());
         }
         else {
-            rehlds::dedicated::TextConsole::print("Unable to open TTY (%s) for output.\n", term_id);
+            rehlds::dedicated::TextConsole::print("Unable to open TTY ({}) for output.\n", term_id);
         }
     }
 

--- a/dedicated/src/dedicated.cpp
+++ b/dedicated/src/dedicated.cpp
@@ -45,7 +45,7 @@ namespace
         auto* const engine_api = engine_module.get_interface<IDedicatedServerApi>(INTERFACE_DEDICATED_SERVER_API);
 
         if (nullptr == engine_api) {
-            TextConsole::print("Failed to retrieve \"%s\" interface.\n", INTERFACE_DEDICATED_SERVER_API);
+            TextConsole::print("Failed to retrieve \"{}\" interface.\n", INTERFACE_DEDICATED_SERVER_API);
         }
 
         return engine_api;
@@ -56,7 +56,7 @@ namespace
         auto* const filesystem = filesystem_module.get_interface<IFileSystem>(INTERFACE_FILESYSTEM);
 
         if (nullptr == filesystem) {
-            TextConsole::print("Failed to retrieve \"%s\" interface.\n", INTERFACE_FILESYSTEM);
+            TextConsole::print("Failed to retrieve \"{}\" interface.\n", INTERFACE_FILESYSTEM);
         }
 
         return filesystem;
@@ -102,7 +102,7 @@ namespace
                 filestream.close();
             }
             else {
-                TextConsole::print("Warning: unable to open PID file (%s)\n", pidfile);
+                TextConsole::print("Warning: unable to open PID file ({})\n", pidfile);
             }
         }
     }

--- a/dedicated/src/dedicated_exports.cpp
+++ b/dedicated/src/dedicated_exports.cpp
@@ -5,11 +5,14 @@
 #include "common/interfaces/dedicated_exports.h"
 #include "common/interface.h"
 #include "common/platform.h"
-#include <cstdio>
+#include "console/text_console.h"
+
+using namespace rehlds::common;
+using namespace rehlds::dedicated;
 
 namespace
 {
-    class DedicatedExports final : public rehlds::common::IDedicatedExports
+    class DedicatedExports final : public IDedicatedExports
     {
       public:
         [[nodiscard]] static IDedicatedExports* instance()
@@ -27,10 +30,9 @@ namespace
     void DedicatedExports::print(const char* const text)
     {
         if ((text != nullptr) && (*text != '\0')) {
-            std::printf("%s", text);
-            std::fflush(stdout);
+            TextConsole::print(text);
         }
     }
 }
 
-EXPOSE_INTERFACE_FN(&DedicatedExports::instance, IDedicatedExports, rehlds::common::INTERFACE_DEDICATED_EXPORTS)
+EXPOSE_INTERFACE_FN(&DedicatedExports::instance, IDedicatedExports, INTERFACE_DEDICATED_EXPORTS)

--- a/dedicated/src/main.cpp
+++ b/dedicated/src/main.cpp
@@ -25,7 +25,7 @@ int main(const int argc, const char* const argv[])
     ::WSADATA data{};
 
     if (const auto error = ::WSAStartup(version, &data); error != 0) {
-        rehlds::dedicated::TextConsole::print("WSAStartup failed with error: %d", error);
+        rehlds::dedicated::TextConsole::print("WSAStartup failed with error: {}", error);
         return -1;
     }
 

--- a/dedicated/src/main.cpp
+++ b/dedicated/src/main.cpp
@@ -2,11 +2,12 @@
  *  ========== Copyright (c) Valve Corporation. All rights reserved. ==========
  */
 
+#include "console/text_console.h"
 #include "dedicated.h"
+#include <clocale>
 
 #ifdef _WIN32
   #define WIN32_LEAN_AND_MEAN // NOLINT(clang-diagnostic-unused-macros)
-  #include "console/text_console.h"
   #include <Windows.h>
   #include <WinSock2.h>
 
@@ -15,6 +16,11 @@
  */
 int main(const int argc, const char* const argv[])
 {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    if (nullptr == std::setlocale(LC_ALL, ".UTF-8")) {
+        rehlds::dedicated::TextConsole::print("WARNING! Could not set locale.\n");
+    }
+
     constexpr auto version = MAKEWORD(2, 2);
     ::WSADATA data{};
 
@@ -37,6 +43,11 @@ int main(const int argc, const char* const argv[])
  */
 int main(const int argc, const char* const argv[])
 {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    if (nullptr == std::setlocale(LC_ALL, "C.UTF-8")) {
+        rehlds::dedicated::TextConsole::print("WARNING! Could not set locale.\n");
+    }
+
     auto& cmdline = rehlds::dedicated::CommandLine::instance();
     cmdline.create(argc, argv);
 


### PR DESCRIPTION
Full support for UTF-8  (without [transcoding](https://github.com/dreamstalker/rehlds/blob/6a916d766b2f766ed9a45f9f008b3f7b737e3c89/rehlds/common/TextConsoleWin32.cpp#L221) to OEM on Windows).

![1](https://user-images.githubusercontent.com/43341889/205597444-c0bca148-9323-423c-bb67-c7c0151f63e6.png)
